### PR TITLE
:bug: Very small checkboxes and arrows on Win10. closes #17

### DIFF
--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -193,8 +193,8 @@ const renderItem = (item) => `
      data-card-id="${item.cardId}"
      data-checklist-id="${item.checklistId}"
      data-item-id="${item.id}" >
-        <span class="aj-checkbox">◽️</span>
-        <span class="aj-checkbox-tick">✔</span>
+        <span class="aj-checkbox checklist-item-checkbox"></span>
+        <span class="aj-checkbox-tick"></span>
         <span class="aj-item-name"> ${renderMarkdown(item.name)} </span>
   </p>`;
 
@@ -328,8 +328,11 @@ function injectCss() {
   }
   .aj-next-step > .aj-checkbox {
     position: absolute;
-    top: 1px;
+    top: -5px;
     left: 2px;
+    box-shadow: none;
+    height: 10px;
+    width: 10px;
   }
   .aj-next-step > .aj-md-hyperlink {
     text-decoration: underline;
@@ -338,7 +341,10 @@ function injectCss() {
     opacity: 0;
     position: absolute;
     top: -1px;
-    left: 5px;
+    left: 4px;
+  }
+  .aj-next-step > .aj-checkbox-tick::before {
+        content: "\\2714"; /* ✔ Checkmark */
   }
   .aj-next-step > .aj-checkbox-tick:hover {
     opacity: 0.5;


### PR DESCRIPTION
Reused Trello's CSS for the box and replaced checkmark by unicode char

The new look in Win10/Chrome 54.0.2840.99:

![nextstepstinycheckboxfix](https://cloud.githubusercontent.com/assets/6100619/20551075/1ecaa78a-b10a-11e6-81d7-c9a3ba941fa1.gif)

@adrienjoly can you review please?
