### PR TITLE
Better markdown support for inline elements

### DIFF
--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -344,7 +344,6 @@ function injectCss() {
 
   .aj-next-step {
     position: relative;
-    overflow: hidden; /* to fix scrolling issue on win10 */
     padding-left: 18px;
     margin-top: 1em;
     font-size: 12px;

--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -183,10 +183,28 @@ function initToolbarSelector(btn) {
   return node;
 }
 
+function getUserName() {
+  let userName = document
+    .getElementsByClassName('header-user')[0]
+    .getElementsByClassName('member-avatar')[0].title;
+  return userName.slice(userName.indexOf('(') + 1, userName.indexOf(')'));
+}
+
+function renderAtMention(userName) {
+  let meClass = userName === '@' + getUserName() ? ' me' : '';
+  return '<span class="atMention' + meClass + '">' + userName + '</span>';
+}
+
 const renderMarkdown = (text) => text
   .replace(/\[(.*)\]\(.*\)/g, '<span class="aj-md-hyperlink">$1</span>')
-  .replace(/https?\:\/\/([^\/ ]+)[^ ]+/g, '<span class=aj-md-hyperlink"">$1</span>')
-  .replace(/\*\*(.*)\*\*/g, '<strong>$1</strong>');
+  .replace(/https?\:\/\/([^\/ ]+)[^ ]+/g, '<span class="aj-md-hyperlink">$&</span>')
+  .replace(/\*\*(.*)\*\*/g, '<strong>$1</strong>')
+  .replace(/__(.*)__/g, '<strong>$1</strong>')
+  .replace(/\*(?!\*)(.*)\*(?!\*)/g, '<em>$1</em>')
+  .replace(/_(?!_)(.*)_(?!_)/g, '<em>$1</em>')
+  .replace(/`{3}(.*)`{3}|`{1}(.*)`{1}/g, '<code>$1$2</code>')
+  .replace(/~~(.*)~~/g, '<del>$1</del>')
+  .replace(/@\w+/g, renderAtMention);
 
 const renderItem = (item) => `
   <p class="aj-next-step"
@@ -343,6 +361,7 @@ function injectCss() {
     width: 10px;
   }
   .aj-next-step > .aj-md-hyperlink {
+  .aj-next-step > .aj-item-name > .aj-md-hyperlink {
     text-decoration: underline;
   }
   .aj-next-step > .aj-checkbox-tick {

--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -359,7 +359,6 @@ function injectCss() {
     height: 10px;
     width: 10px;
   }
-  .aj-next-step > .aj-md-hyperlink {
   .aj-next-step > .aj-item-name > .aj-md-hyperlink {
     text-decoration: underline;
   }


### PR DESCRIPTION
1. Added missing syntax for bold and strikethrough
2. Added both syntaxes for italic,  link and code
3. Fixed the missing underlining of links
3. Added @mention rendering for both the current user and other users
5. Removed overflow fix for Win10

![trellonextsteps_bettermarkdown](https://cloud.githubusercontent.com/assets/6100619/20614525/6382722e-b29d-11e6-88b1-bb2dac6198b9.png)
