### PR TITLE
Markdown formatting bugs

### DIFF
--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -28,7 +28,7 @@ const getFirstResult = (fct) => function() {
 
 // trello checklist processors
 
-const prefixChecklistName = (item) => 
+const prefixChecklistName = (item) =>
   Object.assign(item, {
     name: item.checklistName + ': ' + item.name
   });
@@ -256,18 +256,64 @@ function renderAtMention(userName) {
   return '<span class="atMention' + meClass + '">' + userName + '</span>';
 }
 
-const renderMarkdown = (text) => text
-  // 1) turn plain URLs (non-markdown links) into markdown links
-  .replace(/([^\]][^\(])(https?\:\/\/([^\/ ]+)[^ ]+)/g, '$1[$2]($2)')
-  // 2) turn markdown links into hyperlinks
-  .replace(/\[([^\]]*)\]\(([^\)]*)\)/g, '<a href="$2" class="aj-md-hyperlink">$1</a>')
+const renderMarkdownSymbols = (text) => text
   .replace(/\*\*(.*)\*\*/g, '<strong>$1</strong>')
   .replace(/__(.*)__/g, '<strong>$1</strong>')
   .replace(/\*(?!\*)(.*)\*(?!\*)/g, '<em>$1</em>')
   .replace(/_(?!_)(.*)_(?!_)/g, '<em>$1</em>')
-  .replace(/`{3}(.*)`{3}|`{1}(.*)`{1}/g, '<code>$1$2</code>')
   .replace(/~~(.*)~~/g, '<del>$1</del>')
   .replace(/@\w+/g, renderAtMention);
+
+function getMarkdownPlaceholders(text, regEx) {
+  var placeholders = {};
+  var matches = text.match(regEx);
+  if (matches) {
+    for (var i = 0; i < matches.length; i++) {
+      var name = 'next-step-for-trello-placholder-' + i;
+      placeholders[name] = matches[i];
+    }
+  }
+  return placeholders;
+}
+
+function replaceMarkdownWithPlaceholders(text, placeholders) {
+  for (var name in placeholders) {
+    var markdown = placeholders[name];
+    text = text.replace(markdown, name);
+  }
+  return text;
+}
+
+function renderMarkdownPlaceholders(text, placeholders, regEx, replacement) {
+  for (var name in placeholders) {
+    var html = placeholders[name].replace(regEx, replacement);
+    text = text.replace(name, html);
+  }
+  return text;
+}
+
+function renderMarkdown(text) {
+  // Code and links should not have Markdown formatting applied.  So remove
+  // them from the text and replace with placeholders for now.
+  const codeRegEx = /`{3}(.*)`{3}|`{1}(.*)`{1}/g;
+  var codePlaceholders = getMarkdownPlaceholders(text, codeRegEx);
+  text = replaceMarkdownWithPlaceholders(text, codePlaceholders);
+
+  // Turn plain URLs (non-markdown links) into markdown links
+  text = text.replace(/([^\]][^\(])(https?\:\/\/([^\/ ]+)[^ ]+)/g, '$1[$2]($2)')
+  const urlRegEx =/\[([^\]]*)\]\(([^\)]*)\)/g;
+  var urlPlaceholders = getMarkdownPlaceholders(text, urlRegEx);
+  text = replaceMarkdownWithPlaceholders(text, urlPlaceholders);
+
+  // Apply markdown rendering to the remaining text
+  text = renderMarkdownSymbols(text);
+
+  // Add back the placeholders with HTML code blocks/URLs
+  text = renderMarkdownPlaceholders(text, codePlaceholders, codeRegEx, '<code>$1$2</code>');
+  text = renderMarkdownPlaceholders(text, urlPlaceholders, urlRegEx,'<a href="$2" class="aj-md-hyperlink">$1</a>');
+
+  return text;
+}
 
 const renderItem = (item) => `
   <p class="aj-next-step"
@@ -386,7 +432,7 @@ MENU_ITEMS = MODES.map((mode, i) => {
 
 // extension initialization
 
-const isToolbarInstalled = () => document.getElementById('aj-nextstep-mode'); 
+const isToolbarInstalled = () => document.getElementById('aj-nextstep-mode');
 
 function installToolbar() {
   var headerElements = document.getElementsByClassName('board-header-btns');
@@ -465,7 +511,7 @@ function injectJs(jsString, options) {
   scr.id = options.id;
   scr.textContent = jsString;
   // (appending text to a function to convert it's src to string only works in Chrome)
-  // add to document to make it run, then hide it 
+  // add to document to make it run, then hide it
   (document.head || document.documentElement).appendChild(scr);
   if (options.thenRemove) {
     scr.parentNode.removeChild(scr);
@@ -496,7 +542,7 @@ const INIT_STEPS = [
     callback();
     // inject analytics
     /*
-    injectJs(` 
+    injectJs(`
       window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
         heap.load("3050518868");
     `);
@@ -528,8 +574,8 @@ function getSymbolFromHost(symbolName, callback) {
     callback(e.detail.passback);
   });
   // inject code into the page's context (unrestricted)
-  return ` 
-    var event = document.createEvent("CustomEvent");  
+  return `
+    var event = document.createEvent("CustomEvent");
     event.initCustomEvent("MyCustomEvent_${symbolName}", true, true, {"passback": ${symbolName}});
     window.dispatchEvent(event);`;
 }

--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -308,7 +308,7 @@ function renderMarkdown(text) {
   // Apply markdown rendering to the remaining text
   text = renderMarkdownSymbols(text);
 
-  // Add back the placeholders with HTML code blocks/URLs
+  // Replace the placeholders with HTML code blocks/URLs
   text = renderMarkdownPlaceholders(text, codePlaceholders, codeRegEx, '<code>$1$2</code>');
   text = renderMarkdownPlaceholders(text, urlPlaceholders, urlRegEx,'<a href="$2" class="aj-md-hyperlink">$1</a>');
 

--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -270,7 +270,7 @@ const getMarkdownPatternsToReplace = () => [
     replacement: '<code>$1$2</code>'
   },
   {
-    regEx: /([^\]][^\(])(https?\:\/\/([^\/ ]+)[^ ]+)/g,
+    regEx: /(^|[^\]][^\(])(https?\:\/\/([^\/ ]+)[^ ]+)/g,
     replacement: '$1<a href="$2" class="aj-md-hyperlink">$2</a>'
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "chrome-next-step-for-trello",
+  "version": "1.8.5",
+  "description": "[![Codacy Badge](https://api.codacy.com/project/badge/Grade/7ca1f64573ee434eb82159df9d7afc0f)](https://www.codacy.com/app/adrien-joly/chrome-next-step-for-trello?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=adrienjoly/chrome-next-step-for-trello&amp;utm_campaign=Badge_Grade)",
+  "main": "next-step-for-trello.user.js",
+  "directories": {
+    "doc": "docs",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adrienjoly/chrome-next-step-for-trello.git"
+  },
+  "author": "Adrien Joly <contact@adrienjoly.com> (http://adrienjoly.com/)",
+  "license": "",
+  "bugs": {
+    "url": "https://github.com/adrienjoly/chrome-next-step-for-trello/issues"
+  },
+  "homepage": "https://github.com/adrienjoly/chrome-next-step-for-trello#readme",
+  "devDependencies": {
+    "mocha": "^3.3.0",
+    "mock-browser": "^0.92.14",
+    "sinon-chrome": "^2.2.1"
+  }
+}

--- a/test/renderMarkdown.js
+++ b/test/renderMarkdown.js
@@ -1,0 +1,109 @@
+var vm = require('vm');
+var fs = require('fs');
+var chrome = require('sinon-chrome');
+var assert = require('assert');
+
+// Stop the DEV_MODE const from causing an error
+chrome.runtime.getManifest.returns([]);
+
+// Fake up a browser to stop calls that access the DOM from causing errors
+var MockBrowser = require('mock-browser').mocks.MockBrowser;
+var mock = new MockBrowser();
+var document = mock.getDocument();
+var setInterval = function () {}
+
+// This is the context our tests will run in
+var sandbox = {
+  chrome: chrome,
+  document: document,
+  setInterval: setInterval,
+  returnValue: null
+};
+var context = vm.createContext(sandbox);
+
+// Load the next-step-for-trello code
+var code = fs.readFileSync('next-step-for-trello.user.js')
+const script = new vm.Script(code);
+script.runInContext(context)
+
+// Mock the getUserName function
+var mockGetUserName = 'getUserName = function () { return "test"; }';
+const mockGetUserNameScript = new vm.Script(mockGetUserName);
+mockGetUserNameScript.runInContext(context)
+
+// Set up and run our test cases
+describe('renderMarkdown', function() {
+
+  var tests = [
+    {name: 'url', cases: [
+      {
+        input: 'see http://test.com',
+        expected: 'see <a href="http://test.com" class="aj-md-hyperlink">http://test.com</a>'
+      },
+      {
+        input: 'see https://test.com',
+        expected: 'see <a href="https://test.com" class="aj-md-hyperlink">https://test.com</a>'
+      }
+    ]},
+    {name: 'markdown link', cases: [
+      {
+        input: '[test](http://test.com)',
+        expected: '<a href="http://test.com" class="aj-md-hyperlink">test</a>'
+      }
+    ]},
+    {name: 'strong', cases: [
+      {input: '**test**', expected: '<strong>test</strong>'},
+      {input: '__test__', expected: '<strong>test</strong>'}
+    ]},
+    {name: 'emphasis', cases: [
+      {input: '*test*', expected: '<em>test</em>'},
+      {input: '_test_', expected: '<em>test</em>'}
+    ]},
+    {name: 'code', cases: [
+      {input: '```test```', expected: '<code>test</code>'},
+      {input: '`test`', expected: '<code>test</code>'}
+    ]},
+    {name: 'strike', cases: [
+      {input: '~~test~~', expected: '<del>test</del>'}
+    ]},
+    {name: 'user', cases: [
+      {input: '@notme', expected: '<span class="atMention">@notme</span>'},
+      {input: '@test', expected: '<span class="atMention me">@test</span>'}
+    ]},
+    {name: 'issue 34',cases: [
+      {
+        input: "implementer [l'algo combineEventsWithTasks](https://gist.github.com/adrienjoly/96493349571e2d7166c558ac56fd4d8a) en différenciel => input: tableau d'events (CRUD sur un item), output: tableau d'ordres TableView (deletes, puis updates, puis inserts), cf [Calendar class](https://developer.apple.com/reference/foundation/calendar)",
+        expected: "implementer <a href=\"https://gist.github.com/adrienjoly/96493349571e2d7166c558ac56fd4d8a\" class=\"aj-md-hyperlink\">l'algo combineEventsWithTasks</a> en différenciel => input: tableau d'events (CRUD sur un item), output: tableau d'ordres TableView (deletes, puis updates, puis inserts), cf <a href=\"https://developer.apple.com/reference/foundation/calendar\" class=\"aj-md-hyperlink\">Calendar class</a>"
+      }
+    ]},
+    {name: 'issue 41', cases: [
+      {input: '`*test*.sh`', expected: '<code>*test*.sh</code>'},
+      {input: '`**test**.sh`', expected: '<code>**test**.sh</code>'},
+      {input: '`./run_my_test_.sh`', expected: '<code>./run_my_test_.sh</code>'},
+      {input: '`__init__.py`', expected: '<code>__init__.py</code>'}
+    ]},
+    {name: 'issue 43', cases: [
+      {
+        input: 'créer une landing page en suivant [ce guide](https://medium.com/@cliffordoravec/the-no-bs-approach-to-building-your-saas-startups-launch-list-part-2-of-the-epic-guide-to-8cc371be772c)',
+        expected: 'créer une landing page en suivant <a href="https://medium.com/@cliffordoravec/the-no-bs-approach-to-building-your-saas-startups-launch-list-part-2-of-the-epic-guide-to-8cc371be772c" class="aj-md-hyperlink">ce guide</a>'
+      }
+    ]}
+  ];
+
+  tests.forEach(function(testCase) {
+    describe(testCase.name, function() {
+      testCase.cases.forEach(function(test) {
+        // Reset this in case something goes wrong during the script run
+        sandbox.returnValue = null;
+
+        it('correctly handles ' + test.input, function() {
+          var testScript = new vm.Script(
+            'returnValue = renderMarkdown("' + test.input + '")'
+          );
+          testScript.runInContext(context);
+          assert.equal(sandbox.returnValue, test.expected);
+        });
+      });
+    });
+  });
+});

--- a/test/renderMarkdown.js
+++ b/test/renderMarkdown.js
@@ -87,6 +87,16 @@ describe('renderMarkdown', function() {
         input: 'créer une landing page en suivant [ce guide](https://medium.com/@cliffordoravec/the-no-bs-approach-to-building-your-saas-startups-launch-list-part-2-of-the-epic-guide-to-8cc371be772c)',
         expected: 'créer une landing page en suivant <a href="https://medium.com/@cliffordoravec/the-no-bs-approach-to-building-your-saas-startups-launch-list-part-2-of-the-epic-guide-to-8cc371be772c" class="aj-md-hyperlink">ce guide</a>'
       }
+    ]},
+    {name: 'code and url', cases: [
+      {
+        input: '`wget http://test.com/`',
+        expected: `<code>wget http://test.com/</code>`
+      },
+      {
+        input: '[this site](http://test.com) not working with `wget`',
+        expected: '<a href="http://test.com" class="aj-md-hyperlink">this site</a> not working with <code>wget</code>'
+      }
     ]}
   ];
 

--- a/test/renderMarkdown.js
+++ b/test/renderMarkdown.js
@@ -14,9 +14,9 @@ var setInterval = function () {}
 
 // This is the context our tests will run in
 var sandbox = {
-  chrome: chrome,
-  document: document,
-  setInterval: setInterval,
+  chrome,
+  document,
+  setInterval,
   returnValue: null
 };
 var context = vm.createContext(sandbox);

--- a/test/renderMarkdown.js
+++ b/test/renderMarkdown.js
@@ -37,12 +37,16 @@ describe('renderMarkdown', function() {
   var tests = [
     {name: 'url', cases: [
       {
-        input: 'see http://test.com',
-        expected: 'see <a href="http://test.com" class="aj-md-hyperlink">http://test.com</a>'
+        input: 'http://test.com',
+        expected: '<a href="http://test.com" class="aj-md-hyperlink">http://test.com</a>'
       },
       {
-        input: 'see https://test.com',
-        expected: 'see <a href="https://test.com" class="aj-md-hyperlink">https://test.com</a>'
+        input: 'See http://test.com',
+        expected: 'See <a href="http://test.com" class="aj-md-hyperlink">http://test.com</a>'
+      },
+      {
+        input: 'See https://test.com for details',
+        expected: 'See <a href="https://test.com" class="aj-md-hyperlink">https://test.com</a> for details'
       }
     ]},
     {name: 'markdown link', cases: [


### PR DESCRIPTION
Splits Markdown rendering so that most Markdown does not affect code/URLs.

Unfortunately I can't seem to find a way to make this any simpler... but then I'm not much of a JavaScript developer!

I also have unit tests for the `renderMarkdown` function using Mocha/sinon-chrome/mock-browser.  Happy to submit those if too if they'd be useful - just let me know.