### PR TITLE
Add fix and tests for greedy markdown rendering

### DIFF
--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -333,16 +333,16 @@ function renderAtMention(userName) {
 }
 
 const renderMarkdownSymbols = (text) => text
-  .replace(/\*\*(.*)\*\*/g, '<strong>$1</strong>')
-  .replace(/__(.*)__/g, '<strong>$1</strong>')
-  .replace(/\*(?!\*)(.*)\*(?!\*)/g, '<em>$1</em>')
-  .replace(/_(?!_)(.*)_(?!_)/g, '<em>$1</em>')
-  .replace(/~~(.*)~~/g, '<del>$1</del>')
+  .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
+  .replace(/__(.*?)__/g, '<strong>$1</strong>')
+  .replace(/\*(?!\*)(.*?)\*(?!\*)/g, '<em>$1</em>')
+  .replace(/_(?!_)(.*?)_(?!_)/g, '<em>$1</em>')
+  .replace(/~~(.*?)~~/g, '<del>$1</del>')
   .replace(/@\w+/g, renderAtMention);
 
 const getMarkdownPatternsToReplace = () => [
   {
-    regEx: /`{3}(.*)`{3}|`{1}(.*)`{1}/g,
+    regEx: /`{3}(.*?)`{3}|`{1}(.*?)`{1}/g,
     replacement: '<code>$1$2</code>'
   },
   {
@@ -356,7 +356,7 @@ const getMarkdownPatternsToReplace = () => [
 ];
 
 const getMarkdownPlaceholders = (text) =>
-  getMarkdownPatternsToReplace().reduce((placeholders, pattern) => 
+  getMarkdownPatternsToReplace().reduce((placeholders, pattern) =>
     placeholders.concat((text.match(pattern.regEx) || []).map((match, i) => ({
       name: 'next-step-for-trello-placeholder-' + (placeholders.length + i),
       text: match,
@@ -372,7 +372,7 @@ const renderMdPlaceholder = (placeholder) =>
   placeholder.text.replace(placeholder.regEx, placeholder.replacement);
 
 const renderMarkdownPlaceholders = (text, placeholders) =>
-  placeholders.reduce((text, placeholder) => 
+  placeholders.reduce((text, placeholder) =>
     text.replace(placeholder.name, renderMdPlaceholder(placeholder)), text);
 
 function renderMarkdown(text) {

--- a/test/renderMarkdown.js
+++ b/test/renderMarkdown.js
@@ -101,6 +101,18 @@ describe('renderMarkdown', function() {
         input: '[this site](http://test.com) not working with `wget`',
         expected: '<a href="http://test.com" class="aj-md-hyperlink">this site</a> not working with <code>wget</code>'
       }
+    ]},
+    {name: 'greedy matching', cases: [
+      {input: '*test1* and *test2*', expected: '<em>test1</em> and <em>test2</em>'},
+      {input: '_test1_ and _test2_', expected: '<em>test1</em> and <em>test2</em>'},
+      {input: '**test1** and **test2**', expected: '<strong>test1</strong> and <strong>test2</strong>'},
+      {input: '__test1__ and __test2__', expected: '<strong>test1</strong> and <strong>test2</strong>'},
+      {input: '~~test1~~ and ~~test2~~', expected: '<del>test1</del> and <del>test2</del>'},
+      {input: '`test1` and `test2`', expected: '<code>test1</code> and <code>test2</code>'},
+      {input: '```test1``` and ```test2```', expected: '<code>test1</code> and <code>test2</code>'},
+      {
+        input: '[url1](http://url1.com) and [url2](http://url2.com)',
+        expected: '<a href="http://url1.com" class="aj-md-hyperlink">url1</a> and <a href="http://url2.com" class="aj-md-hyperlink">url2</a>'}
     ]}
   ];
 


### PR DESCRIPTION
Hi Adrien, I noticed an issue with Markdown rendering when you use the same type of markdown more than once in a single checklist item.  Luckily this one was an easier fix :)

![greedy_markdown_before_after](https://cloud.githubusercontent.com/assets/24637079/26800581/bee5831e-4a31-11e7-9974-eac06bd3c39f.jpg)
