### PR TITLE
Check For Active Card

### DIFF
--- a/next-step-for-trello.user.js
+++ b/next-step-for-trello.user.js
@@ -529,6 +529,7 @@ function installToolbar() {
 const elementIsTrelloCard = (element) =>
   element.classList &&
   element.classList.contains('list-card') &&
+  element.classList.contains('active-card') &&
   element.classList.contains('js-member-droppable') &&
   element.classList.contains('ui-droppable');
 


### PR DESCRIPTION
Previous commit 56b7e3b4c9420422c838c77bbd870762168387a6
did some refactoring and pulled out class check into
elementIsTrelloCard(). That is called anytime a DOM node
is inserted and checks to make sure that the thing that
was insterted was a Trello card - if it is a Trello card,
updateCards is called on the new DOM node. Without checking
to see if this new DOM node also has the class 'active-card'
then updateCards is getting called for tons of new DOM nodes
and a lot of those aren't even cards.